### PR TITLE
📝 (config/init.go): add functionality to check if a configuration fil

### DIFF
--- a/internal/commands/config/init.go
+++ b/internal/commands/config/init.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 
 	internalConfig "github.com/proencaj/orthanc-cli/internal/config"
 	"github.com/spf13/cobra"
@@ -16,6 +19,29 @@ func NewInitCommand() *cobra.Command {
 		Short: "Initialize a default configuration file",
 		Long:  `Create a default configuration file at ~/.orthanc-cli.yaml with example settings.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check if config file already exists
+			exists, path, err := internalConfig.ConfigExists(outputPath)
+			if err != nil {
+				return fmt.Errorf("failed to check config file: %w", err)
+			}
+
+			if exists {
+				fmt.Printf("Configuration file already exists at %s\n", path)
+				fmt.Print("Do you want to overwrite it? [y/N]: ")
+
+				reader := bufio.NewReader(os.Stdin)
+				response, err := reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("failed to read response: %w", err)
+				}
+
+				response = strings.TrimSpace(strings.ToLower(response))
+				if response != "y" && response != "yes" {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
 			if err := internalConfig.SaveConfig(outputPath); err != nil {
 				return fmt.Errorf("failed to create config file: %w", err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,22 @@ func migrateConfig(config *Config) error {
 	return nil
 }
 
+// ConfigExists checks if a configuration file already exists at the given path
+func ConfigExists(path string) (bool, string, error) {
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return false, "", err
+		}
+		path = filepath.Join(home, ".orthanc-cli.yaml")
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		return true, path, nil
+	}
+	return false, path, nil
+}
+
 // SaveConfig creates a default configuration file
 func SaveConfig(path string) error {
 	if path == "" {


### PR DESCRIPTION
…e already exists before creating a new one

Closes #4 

📝 (config/init.go): prompt user to confirm overwriting existing configuration file
📝 (config/init.go): handle user response to overwrite or abort creating a new configuration file
📝 (config/config.go): implement function to check if a configuration file already exists at a given path